### PR TITLE
message types and payloads

### DIFF
--- a/message-types.js
+++ b/message-types.js
@@ -1,0 +1,47 @@
+if(typeof(window) != "undefined") {
+	var exports = window;
+} else {
+}
+
+exports.EMAIL_REGISTER = "register"; // A new email account has been created
+exports.EMAIL_SEND = "send"; // An email has been sent
+
+exports.GENERAL_ACTIVATE = "activate"; // Activate torwolf?
+exports.GENERAL_DEACTIVATE = "deactivate"; // Deactivate torwolf?
+exports.GENERAL_ERROR = "error"; // An error has occurred
+
+exports.IRC_CONNECT = "connect"; // A player has connected to IRC
+exports.IRC_DISCONNECT = "disconnect" // a player has disconnected from IRC
+exports.IRC_MESSAGE = "message"; // An IRC message has been sent
+exports.IRC_JOIN = "join"; // A player has joined an IRC channel
+exports.IRC_LEAVE = "leave"; // A player has left an IRC channel
+exports.IRC_NICK = "switch nick"; // A player has switched nicks
+
+exports.LOBBY_CONNECT = "connect" // A player has connected to the lobby
+exports.LOBBY_CREATE = "create"; // A new game has been created
+exports.LOBBY_JOIN = "join"; // A player has joined the lobby
+
+exports.NEWSPAPER_PUBLISH = "publish"; // A paper has been published
+
+exports.SNOOPER_INTERCEPT = "intercept"; // A plaintext message has been intercepted
+exports.SNOOPER_SSL = "ssl"; // An encrypted message has been intercepted
+exports.SNOOPER_TOR = "tor"; // A player has joined or used the tor network
+exports.SNOOPER_WIRETAP = "wiretap"; // A wiretap has been put in place
+
+exports.STORYTELLER_ALLEGIANCE = "allegiance"; // Change allegiance / Set allegiance
+exports.STORYTELLER_ANNOUNCEMENT = "announcement"; // Make an announcement
+exports.STORYTELLER_END = "end"; // End the game
+exports.STORYTELLER_HEARTBEAT = "heartbeat"; // Announce a heartbeat
+exports.STORYTELLER_INVESTIGATE = "investigate"; // look into an issue
+exports.STORYTELLER_KILL = "kill"; // A player has been killed
+exports.STORYTELLER_JOIN = "join"; // Join a game / someone has joined
+exports.STORYTELLER_LEAVE = "leave"; // Leave a game / someone has left
+exports.STORYTELLER_ROLE = "setrole"; // Specify role preference / Set role
+exports.STORYTELLER_RUMOR = "rumor"; // Give the person a rumor
+exports.STORYTELLER_START = "start"; // The game has started 
+exports.STORYTELLER_TICK = "tick"; // Trigger a tick / announce a tick
+
+exports.TOR_CONNECT = "connect"; // Connect to Tor
+exports.TOR_DISCONNECT = "disconnect"; // Disconnect from Tor
+exports.TOR_ROUTE = "route"; // Send a package to be routed through Tor
+exports.TOR_EDUCATION = "tor education" // Teach a player about the Tor network

--- a/payloads.js
+++ b/payloads.js
@@ -1,0 +1,793 @@
+
+if(typeof(window) != "undefined") {
+	var exports = window;
+	var constants = window;
+} else {
+	constants = require('./message-types');
+	locales = require('./locales/default.js');
+}
+
+// Generic Payloads
+exports.ErrorPayload = function(content) {
+	this.content = content;
+	this.getPayload = function() {
+		return {
+			type: constants.GENERAL_ERROR,
+			data: {
+				content: this.content
+			}
+		}
+	};
+};
+
+exports.ActivatePayload = function(content) {
+	this.getPayload = function() {
+		return {
+			type: constants.GENERAL_ACTIVATE,
+			data: {
+			}
+		}
+	};
+};
+
+exports.DeactivatePayload = function(content) {
+	this.getPayload = function() {
+		return {
+			type: constants.GENERAL_DEACTIVATE,
+			data: {
+			}
+		}
+	};
+};
+
+
+// Module Payloads
+exports.EmailRegisterInPayload = function(account) {
+	this.account = account;
+	this.getPayload = function() {
+		return {
+			type: constants.EMAIL_REGISTER,
+			data: {
+				address: this.account.address
+			}
+		}
+	};
+};
+
+exports.EmailRegisterOutPayload = function(account) {
+	this.account = account;
+	this.getPayload = function() {
+		return {
+			type: constants.EMAIL_REGISTER,
+			data: {
+				accountId: this.account.id,
+				address: this.account.address,
+				playerId: (this.account.player == null)?'':this.account.player.id
+			}
+		}
+	};
+};
+
+exports.EmailSendInPayload = function(message) {
+	this.message = message;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.EMAIL_SEND,
+			data: {
+				bccAddresses: this.message.bccAddresses,
+				body: this.message.body,
+				ccAddresses: this.message.ccAddresses,
+				fromAddress: this.message.fromAddress,
+				rumorIds: this.message.rumorIds,
+				subject: this.message.subject,
+				toAddresses: this.message.toAddresses
+			}
+		}
+	};
+};
+
+exports.EmailSendOutPayload = function(message) {
+	this.message = message;
+	
+	this.getPayload = function() {
+		var ccAddresses = [];
+		var toAddresses = [];
+		for(var x in message.cc)
+			ccAddresses.push(message.cc[x].address);
+		for(var x in message.to)
+			toAddresses.push(message.to[x].address);
+		
+		return {
+			type: constants.EMAIL_SEND,
+			data: {
+				body: this.message.body,
+				ccAddresses: ccAddresses,
+				fromAddress: this.message.from.address,
+				subject: this.message.subject,
+				toAddresses: toAddresses
+			}
+		}
+	};
+};
+
+
+exports.IrcConnectOutPayload = function(message) {
+	this.message = message;
+	this.user =  message.user;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_CONNECT,
+			data: {
+				messageId: this.message.id,
+				playerId: this.user.player.id,
+				text: this.message.text,
+				type: this.message.type,
+				userId: this.user.id
+			}
+		}
+	};
+};
+
+exports.IrcMessageInPayload = function(text) {
+	this.text = text;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_MESSAGE,
+			data: {
+				text: this.text
+			}
+		}
+	};
+};
+
+exports.IrcMessageOutPayload = function(message) {
+	this.message = message;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_MESSAGE,
+			data: {
+				messageId: this.message.id,
+				text: this.message.text,
+				type: this.message.type,
+				userId: this.message.user.id
+			}
+		}
+	};
+};
+
+exports.IrcJoinInPayload = function(nick) {
+	this.nick = nick;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_JOIN,
+			data: {
+				nick: this.nick
+			}
+		}
+	};
+};
+
+exports.IrcJoinOutPayload = function(user) {
+	this.user = user;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_JOIN,
+			data: {
+				playerId: this.user.player.id,
+				userId: this.user.id,
+				nick: this.user.nick
+			}
+		}
+	};
+};
+
+exports.IrcNickOutPayload = function(user) { 
+	this.user = user;
+	this.getPayload = function() {
+		return {
+			type: constants.IRC_NICK,
+			data: {
+				nick: this.user.nick,
+				userId: this.user.id
+			}
+		}
+	}
+};
+
+exports.LobbyConnectInPayload = function(name) {
+	this.name = name;
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_CONNECT,
+			data: {
+				name: this.name
+			}
+		}
+	};
+};
+
+exports.LobbyConnectOutPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_CONNECT,
+			data: {
+				playerId: this.player.id,
+				name: this.player.name
+			}
+		}
+	};
+};
+
+exports.LobbyCreateInPayload = function(game) {
+	this.name = game.name;
+	this.password = game.password;
+	this.isPrivate = game.isPrivate;
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_CREATE,
+			data: {
+				name: this.name,
+				password: this.password,
+				isPrivate: this.isPrivate
+			}
+		}
+	};
+};
+
+exports.LobbyCreateOutPayload = function(game) {
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_CREATE,
+			data: {
+				gameId: this.game.id,
+				isPrivate: this.game.isPrivate,
+				locale: this.game.locale,
+				maxPlayers: this.game.maxPlayers,
+				name: this.game.name,
+				players: this.game.players,
+				roles: this.game.roles,
+				rumorCount: this.game.rumorCount,
+				tickLength: this.game.tickLength
+			}
+		}
+	};
+}
+
+exports.LobbyJoinInPayload = function(game) {
+	this.game = game;
+	this.password = "";
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_JOIN,
+			data: {
+				gameId: this.game.id,
+				password: this.password
+			}
+		}
+	};
+};
+
+exports.LobbyJoinOutPayload = function(player, game) {
+	this.player = player;
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.LOBBY_JOIN,
+			data: {
+				playerId: this.player.id,
+				gameId: this.game.id
+			}
+		}
+	}
+}
+
+
+exports.NewspaperPublishInPayload = function(game) {
+	this.game = game
+	
+	this.getPayload = function() {
+		return {
+			type: constants.NEWSPAPER_PUBLISH,
+			data: {
+				gameId: this.game.id
+			}
+		}
+	}
+}
+
+exports.NewspaperPublishOutPayload = function(edition) {
+	this.edition = edition;
+	
+	this.getPayload = function() {
+		var rumorIds = [];
+		for(var x in this.edition.rumors)
+			rumorIds.push(this.edition.rumors[x].id);
+		
+		return {
+			type: constants.NEWSPAPER_PUBLISH,
+			data: {
+				copy: this.edition.copy,
+				editionId: this.edition.id,
+				headline: this.edition.headline,
+				round: this.edition.round,
+				rumorIds: rumorIds
+			}
+		}
+	}
+}
+
+
+exports.SnooperInterceptInPayload = function(interaction) {
+	this.interaction = interaction;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_INTERCEPT,
+			data: {
+				interactionId: this.interaction.id
+			}
+		}
+	}
+}
+
+exports.SnooperInterceptOutPayload = function(interaction, player) {
+	this.interaction = interaction;
+	this.player = player;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_INTERCEPT,
+			data: {
+				interactionId: this.interaction.id,
+				message: this.interaction.message,
+				playerId: this.player?this.player.id:"",
+				responses: this.interaction.responses
+			}
+		}
+	}
+}
+
+exports.SnooperSslInPayload = function() {
+	this.getPayload = function() {
+		return {
+		}
+	}
+}
+
+exports.SnooperSslOutPayload = function(player, target) {
+	this.player = player;
+	this.target = target;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_TOR,
+			data: {
+				playerId: this.player.id,
+				target: this.target
+			}
+		}
+	}
+}
+
+exports.SnooperTorInPayload = function() {
+	this.getPayload = function() {
+		return {
+		}
+	}
+}
+
+exports.SnooperTorOutPayload = function(player, state) {
+	this.player = player;
+	this.state = state;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_TOR,
+			data: {
+				playerId: this.player.id,
+				state: this.state
+			}
+		}
+	}
+}
+
+exports.SnooperWiretapInPayload = function(player) {
+	this.player = player;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_WIRETAP,
+			data: {
+				playerId: player.id
+			}
+		}
+	}
+}
+
+exports.SnooperWiretapOutPayload = function(player) {
+	this.player = player;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.SNOOPER_WIRETAP,
+			data: {
+				playerId: player.id
+			}
+		}
+	}
+}
+
+
+exports.StorytellerAllegianceInPayload = function() {
+}
+
+exports.StorytellerAllegianceOutPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_ALLEGIANCE,
+			data: {
+				playerId: this.player.id,
+				allegiance: this.player.allegiance 
+			}
+		}
+	}
+}
+
+exports.StorytellerAnnouncementInPayload = function() {
+}
+
+exports.StorytellerAnnouncementOutPayload = function(text) {
+	this.text = text;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_ANNOUNCEMENT,
+			data: {
+				text: this.text
+			}
+		}
+	}
+}
+
+
+exports.StorytellerEndInPayload = function(game) {
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_END,
+			data: {
+				gameId: this.game.id
+			}
+		}
+	}
+}
+
+exports.StorytellerEndOutPayload = function(game) {
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_END,
+			data: {
+				gameId: this.game.id,
+			}
+		}
+	}
+}
+
+
+exports.StorytellerHeartbeatInPayload = function(game) {
+	this.game = game;
+	this.count = 0;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_HEARTBEAT,
+			data: {
+				gameId: this.game.id,
+				count: this.count
+			}
+		}
+	};
+};
+
+exports.StorytellerHeartbeatOutPayload = function(count) {
+	this.count = count;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_HEARTBEAT,
+			data: {
+				count: this.count,
+			}
+		}
+	};
+}
+
+exports.StorytellerInvestigateInPayload = function(rumor) {
+	this.rumor = rumor;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_INVESTIGATE,
+			data: {
+				rumorId: this.rumor.id
+			}
+		}
+	};
+};
+
+exports.StorytellerInvestigateOutPayload = function() {
+}
+
+exports.StorytellerJoinInPayload = function(player, game) {
+	this.game = game;
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_JOIN,
+			data: {
+				gameId: this.game.id,
+				playerId: this.player.id
+			}
+		}
+	};
+};
+
+exports.StorytellerJoinOutPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_JOIN,
+			data: {
+				playerId: this.player.id,
+				status: this.player.status,
+				name: this.player.name,
+				role: constants.PLAYER_ROLE_UNKNOWN,
+				allegiance: constants.PLAYER_ALLEGIANCE_UNKNOWN
+			}
+		}
+	}
+}
+
+exports.StorytellerKillInPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_KILL,
+			data: {
+				playerId: this.player.id
+			}
+		}
+	}
+}
+
+exports.StorytellerKillOutPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_KILL,
+			data: {
+				playerId: this.player.id,
+			}
+		}
+	}
+}
+
+exports.StorytellerRoleInPayload = function() {
+}
+
+exports.StorytellerRoleOutPayload = function(player) {
+	this.player = player;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_ROLE,
+			data: {
+				playerId: this.player.id,
+				role: this.player.role 
+			}
+		}
+	}
+}
+
+exports.StorytellerRumorInPayload = function(rumor) {
+	this.destinationId = "";
+	this.rumor = rumor;
+	this.sourceId = "";
+	this.truthStatus = "";
+	
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_RUMOR,
+			data: {
+				destinationId: this.destinationId,
+				rumorId: this.rumor.id,
+				sourceId: this.sourceId,
+				truthStatus: this.truthStatus
+			}
+		}
+	}
+	
+}
+
+exports.StorytellerRumorOutPayload = function(rumor) {
+	this.destinationId = "";
+	this.rumor = rumor;
+	this.sourceId = "";
+	this.truthStatus = "";
+	
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_RUMOR,
+			data: {
+				destinationId: this.destinationId,
+				publicationStatus: this.rumor.publicationStatus,
+				rumorId: this.rumor.id,
+				sourceId: this.sourceId,
+				text: this.rumor.text,
+				truthStatus: this.truthStatus
+			}
+		}
+	}
+}
+
+exports.StorytellerStartInPayload = function(game) {
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_START,
+			data: {
+				gameId: this.game.id 
+			}
+		}
+	}
+}
+
+exports.StorytellerStartOutPayload = function(game) {
+}
+
+exports.StorytellerTickInPayload = function(game) {
+	this.game = game;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_TICK,
+			data: {
+				gameId: this.game.id,
+			}
+		}
+	};
+};
+
+exports.StorytellerTickOutPayload = function(game) {
+	this.game = game;
+	this.getPayload = function() {
+		return {
+			type: constants.STORYTELLER_TICK,
+			data: {
+				round: this.game.round
+			}
+		}
+	};
+}
+
+
+exports.TorBridgeInPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_BRIDGE,
+			data: {
+			}
+		}
+	};
+};
+
+exports.TorBridgeOutPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_BRIDGE,
+			data: {
+			}
+		}
+	};
+}
+
+exports.TorConnectInPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_CONNECT,
+			data: {
+			}
+		}
+	};
+};
+
+exports.TorConnectOutPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_CONNECT,
+			data: {
+			}
+		}
+	};
+}
+
+exports.TorDisconnectInPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_DISCONNECT,
+			data: {
+			}
+		}
+	};
+};
+
+exports.TorDisconnectOutPayload = function() {
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_DISCONNECT,
+			data: {
+			}
+		}
+	};
+}
+
+exports.TorRouteInPayload = function(message) {
+	this.message = message;
+	this.bridgeId = "";
+	
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_ROUTE,
+			data: {
+				bridgeId: this.bridgeId,
+				message: this.message
+			}
+		}
+	};
+};
+
+exports.TorRouteOutPayload = function(message) {
+	this.message = message;
+	this.bridgeId = "";
+	
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_ROUTE,
+			data: {
+				bridgeId: this.bridgeId,
+				message: this.message
+			}
+		}
+	};
+}
+
+exports.TorEducateOutPayload = function(teacherId, studentId) {
+	this.teacherId = teacherId;
+	this.studentId = studentId;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_EDUCATION,
+			data: {
+				teacherId: this.teacherId,
+				studentId: this.studentId
+			}
+		}
+	};
+}
+
+exports.TorEducateInPayload = function(message) {
+	this.teacherId = teacherId;
+	this.studentId = studentId;
+	
+	this.getPayload = function() {
+		return {
+			type: constants.TOR_EDUCATION,
+			data: {
+				teacherId: this.teacherId,
+				studentId: this.studentId
+			}
+		}
+	};
+}


### PR DESCRIPTION
I mostly copypasta'd this from master, because I think it was pretty elegant and complete as-is. I did split off the payload type constants to its own file, so we get more concise names, and added a bit of documentation.

I do want to discuss, at some point, splitting up "action" messages from "event" messages, since it means that a specific message "type" ends up taking on too much responsibility. For example, you need contextual information to process a payload (you can't tell just from the type.) That's not so bad, since it's usually pretty easy to tell if it's coming from a server or going to a server, but it seems like "easier -> better" here, especially for people who are new to the project.

I think, ideally, payload types would be one to one with message types, which means that it's very easy to know what's in a payload and what the significance of a message at a quick glance and without know too much about the overall project architecture. You can just take an appropriate action.

So for example, EMAIL_EMAIL could be split up into EMAIL_SEND and EMAIL_SENT. EMAIL_SEND is a message to the server (an In payload), and EMAIL_SENT is a message to the client, with which the client would process and display the email, if applicable.

If we agree, I think we can just add an issue and call it good, for now, unless you'd like to tackle it soon.
